### PR TITLE
I18n support

### DIFF
--- a/packages/typography/doc/index.tsx
+++ b/packages/typography/doc/index.tsx
@@ -6,7 +6,7 @@ const tunaLight: FontFace = {
   name: "Tuna Light",
 
   fontFamily: "Tuna",
-  fallback: ["Arial", "serif"],
+  fallback: ["Roboto Slab", "serif"],
 
   cssProperties: {
     fontWeight: 100,
@@ -18,7 +18,7 @@ const tunaRegular: FontFace = {
   name: "Tuna Regular",
 
   fontFamily: "Tuna",
-  fallback: ["Arial", "serif"],
+  fallback: ["Roboto Slab", "serif"],
 
   cssProperties: {
     fontWeight: 400,
@@ -30,7 +30,7 @@ const tunaRegularItalic: FontFace = {
   name: "Tuna Regular Italic",
 
   fontFamily: "Tuna",
-  fallback: ["Arial", "serif"],
+  fallback: ["Roboto Slab", "serif"],
 
   cssProperties: {
     fontWeight: 400,
@@ -42,7 +42,7 @@ const tunaBold: FontFace = {
   name: "Tuna Bold",
 
   fontFamily: "Tuna",
-  fallback: ["Arial", "serif"],
+  fallback: ["Roboto Slab", "serif"],
 
   cssProperties: {
     fontWeight: 700,
@@ -54,7 +54,7 @@ const tunaBoldItalic: FontFace = {
   name: "Tuna Bold",
 
   fontFamily: "Tuna",
-  fallback: ["Arial", "serif"],
+  fallback: ["Roboto Slab", "serif"],
 
   cssProperties: {
     fontWeight: 700,
@@ -186,7 +186,7 @@ const tunaLight: FontFace = {
   name: "Tuna Light",
 
   fontFamily: "Tuna",
-  fallback: ["Arial", "serif"],
+  fallback: ["Roboto Slab", "serif"],
 
   cssProperties: {
     fontWeight: 100,

--- a/packages/typography/doc/index.tsx
+++ b/packages/typography/doc/index.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import { FontFace, Matrix, Fallback, Font, fontUsageCSS } from "../src/index";
 import { markdown } from "@catalog/core";
+import * as React from "react";
+import { Fallback, Font, FontFace, fontUsageCSS, Matrix } from "../src/index";
 
 const tunaLight: FontFace = {
   name: "Tuna Light",

--- a/packages/typography/src/fallback.tsx
+++ b/packages/typography/src/fallback.tsx
@@ -1,11 +1,16 @@
+import { Theme } from "@catalog/core";
+import styled from "@emotion/styled";
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import styled from "@emotion/styled";
-import { Theme } from "@catalog/core";
 import { FontFace } from "./types";
 
 export interface FallbackProps {
   fontFaces: Array<FontFace>;
+
+  /**
+   * Use this to provide your own sample text.
+   */
+  sample?: React.ReactNode;
 }
 
 interface State {
@@ -38,7 +43,7 @@ export class Fallback extends React.PureComponent<FallbackProps, State> {
 
   render() {
     const { catalog } = this.context;
-    const { fontFaces } = this.props;
+    const { fontFaces, sample = defaultSample } = this.props;
     const { cut, activeFallback } = this.state;
 
     return (
@@ -93,7 +98,7 @@ export class Fallback extends React.PureComponent<FallbackProps, State> {
   }
 }
 
-const sample = (
+const defaultSample = (
   <>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
     aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/packages/typography/src/fallback.tsx
+++ b/packages/typography/src/fallback.tsx
@@ -45,6 +45,7 @@ export class Fallback extends React.PureComponent<FallbackProps, State> {
     const { catalog } = this.context;
     const { fontFaces, sample = defaultSample } = this.props;
     const { cut, activeFallback } = this.state;
+    const fontStack = activeFontStack(cut, activeFallback)
 
     return (
       <Root theme={catalog.theme}>
@@ -89,7 +90,7 @@ export class Fallback extends React.PureComponent<FallbackProps, State> {
               {sample}
             </div>
             {activeFallback && (
-              <FallbackOverlay style={{ ...cut.cssProperties, fontFamily: activeFallback }}>{sample}</FallbackOverlay>
+              <FallbackOverlay style={{ ...cut.cssProperties, fontFamily: fontStack }}>{sample}</FallbackOverlay>
             )}
           </Sample>
         </SampleContainer>
@@ -186,3 +187,9 @@ const FallbackOverlay = styled("div")`
 
 const getFontSize = ({ baseFontSize, msRatio }: Theme, level: number = 0) =>
   `${(baseFontSize / 16) * Math.pow(msRatio, level)}em`;
+
+const  activeFontStack = (cut: FontFace, activeFallback: undefined | string) => {
+  const stack = [cut.fontFamily, ...cut.fallback]
+  const stackIndex = activeFallback ? stack.indexOf(activeFallback) : 0
+  return stack.slice(stackIndex).join(',')
+}

--- a/packages/typography/src/font.tsx
+++ b/packages/typography/src/font.tsx
@@ -2,7 +2,7 @@ import { Theme } from "@catalog/core";
 import styled from "@emotion/styled";
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import { FontFace } from "./types";
+import { cssFontStack, FontFace } from "./types";
 
 export interface FontProps {
   name: string;
@@ -47,7 +47,7 @@ export class Font extends React.PureComponent<FontProps, State> {
     const { catalog } = this.context;
     const { name, fontFace, sample, usage, cssProperties } = this.props;
     const { selectedTab } = this.state;
-    const fontStack = getFontStack(fontFace)
+    const fontStack = cssFontStack(fontFace)
 
     return (
       <Root>
@@ -208,9 +208,6 @@ const Definition = styled("div")<{ theme: Theme }>`
 const getFontSize = ({ baseFontSize, msRatio }: Theme, level: number = 0) =>
   `${(baseFontSize / 16) * Math.pow(msRatio, level)}em`;
 
-const getFontStack = (  fontFace: FontFace  ) => 
-   [fontFace.fontFamily, ...fontFace.fallback].join(',')
-
 const toKebabCase = (str: string) => str.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 
 export const fontUsageCSS = ({ cssProperties }: FontProps, { catalog }: { catalog: any }) => (
@@ -248,7 +245,7 @@ class ComputedStyle extends React.PureComponent<
   render() {
     const { name, fontFace, cssProperties, catalog } = this.props;
     const { style } = this.state;
-    const fontStack = getFontStack(fontFace)
+    const fontStack = cssFontStack(fontFace)
 
     const relevantProperties: any = {};
     if (style) {

--- a/packages/typography/src/font.tsx
+++ b/packages/typography/src/font.tsx
@@ -1,7 +1,7 @@
+import { Theme } from "@catalog/core";
+import styled from "@emotion/styled";
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import styled from "@emotion/styled";
-import { Theme } from "@catalog/core";
 import { FontFace } from "./types";
 
 export interface FontProps {
@@ -44,6 +44,7 @@ export class Font extends React.PureComponent<FontProps, State> {
     const { catalog } = this.context;
     const { name, fontFace, sample, usage, cssProperties } = this.props;
     const { selectedTab } = this.state;
+    const fontStack = getFontStack(fontFace)
 
     return (
       <Root>
@@ -96,12 +97,12 @@ export class Font extends React.PureComponent<FontProps, State> {
         <div>
           <div>
             {selectedTab === "PANGRAM" && (
-              <Pangram style={{ fontFamily: fontFace.fontFamily, ...fontFace.cssProperties, ...cssProperties }}>
+              <Pangram style={{ fontFamily: fontStack, ...fontFace.cssProperties, ...cssProperties }}>
                 The quick brown fox jumps over the lazy dog
               </Pangram>
             )}
             {selectedTab === "SAMPLE" && (
-              <Sample style={{ fontFamily: fontFace.fontFamily, ...fontFace.cssProperties, ...cssProperties }}>
+              <Sample style={{ fontFamily: fontStack, ...fontFace.cssProperties, ...cssProperties }}>
                 {sample}
               </Sample>
             )}
@@ -204,6 +205,9 @@ const Definition = styled("div")<{ theme: Theme }>`
 const getFontSize = ({ baseFontSize, msRatio }: Theme, level: number = 0) =>
   `${(baseFontSize / 16) * Math.pow(msRatio, level)}em`;
 
+const getFontStack = (  fontFace: FontFace  ) => 
+   [fontFace.fontFamily, ...fontFace.fallback].join(',')
+
 const toKebabCase = (str: string) => str.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 
 export const fontUsageCSS = ({ cssProperties }: FontProps, { catalog }: { catalog: any }) => (
@@ -241,6 +245,7 @@ class ComputedStyle extends React.PureComponent<
   render() {
     const { name, fontFace, cssProperties, catalog } = this.props;
     const { style } = this.state;
+    const fontStack = getFontStack(fontFace)
 
     const relevantProperties: any = {};
     if (style) {
@@ -257,7 +262,7 @@ class ComputedStyle extends React.PureComponent<
     return (
       <>
         <div
-          style={{ fontFamily: fontFace.fontFamily, ...fontFace.cssProperties, ...cssProperties }}
+          style={{ fontFamily: fontStack, ...fontFace.cssProperties, ...cssProperties }}
           ref={this.extractComputedProperties}
         />
 

--- a/packages/typography/src/font.tsx
+++ b/packages/typography/src/font.tsx
@@ -36,9 +36,12 @@ export class Font extends React.PureComponent<FontProps, State> {
   };
   context!: { catalog: any };
 
-  state: State = {
-    selectedTab: "PANGRAM"
-  };
+  constructor(props: FontProps) {
+    super(props)
+    this.state = {
+      selectedTab: props.sample ? 'SAMPLE' : 'PANGRAM'
+    }
+  }
 
   render() {
     const { catalog } = this.context;

--- a/packages/typography/src/matrix.tsx
+++ b/packages/typography/src/matrix.tsx
@@ -1,7 +1,7 @@
+import { Theme } from "@catalog/core";
+import styled from "@emotion/styled";
 import * as PropTypes from "prop-types";
 import * as React from "react";
-import styled from "@emotion/styled";
-import { Theme } from "@catalog/core";
 import { FontFace } from "./types";
 
 export interface MatrixProps {
@@ -31,7 +31,7 @@ export class Matrix extends React.PureComponent<MatrixProps> {
             if (cut) {
               return <div style={{ ...cut.cssProperties, fontFamily: cut.fontFamily }}>{cut.name}</div>;
             } else {
-              return <Unused theme={catalog.theme}>Not Available</Unused>;
+              return <Unused theme={catalog.theme}>{capitalize(style)} ({weight}) not available</Unused>;
             }
           });
         })}
@@ -71,3 +71,5 @@ const Unused = styled("div")<{ theme: Theme }>`
 
 const getFontSize = ({ baseFontSize, msRatio }: Theme, level: number = 0) =>
   `${(baseFontSize / 16) * Math.pow(msRatio, level)}em`;
+
+const capitalize = (str: string) => `${str[0].toUpperCase()}${str.slice(1)}`

--- a/packages/typography/src/types.tsx
+++ b/packages/typography/src/types.tsx
@@ -34,8 +34,8 @@ export interface FontFace {
  * string for use with the CSS font-family property.
  * 
  * @example
- * const fontFace = { fontFamily: 'Nice Font', fallback: ['Arial', 'sans-serif'], ... }
- * cssFontStack(fontFace) // "'Nice Font', Arial, sans-serif"
+ * const fontFace = { fontFamily: 'Tuna', fallback: ['Roboto Slab', 'serif'], ... }
+ * cssFontStack(fontFace) // "Tuna, 'Roboto Slab', serif"
  */
 export const cssFontStack = (fontFace: FontFace) => {
   const hasSpaces = /\s+/

--- a/packages/typography/src/types.tsx
+++ b/packages/typography/src/types.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { FontFamilyProperty } from "csstype";
+import * as React from "react";
 
 export interface FontFace {
   /**
@@ -27,4 +27,18 @@ export interface FontFace {
    * across the base font and all fallback fonts.
    */
   cssProperties: React.CSSProperties;
+}
+
+/**
+ * Render a FontFace's fontFamily and fallback font families as a CSS font stack
+ * string for use with the CSS font-family property.
+ * 
+ * @example
+ * const fontFace = { fontFamily: 'Nice Font', fallback: ['Arial', 'sans-serif'], ... }
+ * cssFontStack(fontFace) // "'Nice Font', Arial, sans-serif"
+ */
+export const cssFontStack = (fontFace: FontFace) => {
+  const hasSpaces = /\s+/
+  const wrapInQuotes = (x: string) => hasSpaces.test(x) ? `"${x}"` : x
+  return [fontFace.fontFamily, ...fontFace.fallback].map(wrapInQuotes).join(',')
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import { Catalog, markdown } from "@catalog/core";
-import { Global, css } from "@emotion/core";
+import { css, Global } from "@emotion/core";
+import * as React from "react";
 
 const globalStyles = css`
-  /* Light */
+  /* Tuna Light */
   @font-face {
     font-family: Tuna;
     font-style: normal;
@@ -11,7 +11,7 @@ const globalStyles = css`
     src: url(${require("../fonts/Tuna/371F3E_3_0.woff2")}) format("woff2");
   }
 
-  /* LightItalic */
+  /* Tuna LightItalic */
   @font-face {
     font-family: Tuna;
     font-style: italic;
@@ -19,7 +19,7 @@ const globalStyles = css`
     src: url(${require("../fonts/Tuna/371F3E_5_0.woff2")}) format("woff2");
   }
 
-  /* Regular */
+  /* Tuna Regular */
   @font-face {
     font-family: Tuna;
     font-style: normal;
@@ -27,7 +27,7 @@ const globalStyles = css`
     src: url(${require("../fonts/Tuna/371F3E_7_0.woff2")}) format("woff2");
   }
 
-  /* RegularItalic */
+  /* Tuna RegularItalic */
   @font-face {
     font-family: Tuna;
     font-style: italic;
@@ -35,7 +35,7 @@ const globalStyles = css`
     src: url(${require("../fonts/Tuna/371F3E_9_0.woff2")}) format("woff2");
   }
 
-  /* Bold */
+  /* Tuna Bold */
   @font-face {
     font-family: Tuna;
     font-style: normal;
@@ -43,13 +43,16 @@ const globalStyles = css`
     src: url(${require("../fonts/Tuna/371F3E_0_0.woff2")}) format("woff2");
   }
 
-  /* BoldItalic */
+  /* Tuna BoldItalic */
   @font-face {
     font-family: Tuna;
     font-style: italic;
     font-weight: 700;
     src: url(${require("../fonts/Tuna/371F3E_1_0.woff2")}) format("woff2");
   }
+
+  /* Fallback font for examples: Roboto Slab */
+  @import url('https://fonts.googleapis.com/css?family=Roboto+Slab&display=swap');
 
   body {
     ul[class*="Menu-className"] {


### PR DESCRIPTION
The goal of these changes is to make it possible to showcase non-latin-based typefaces, e.g. Arabic or Chinese. I think with this it should now be possible.

I decided to also make the sample text selected by default if one is provided as showing a latin pangram for an Arabic font doesn't make any sense …